### PR TITLE
Fix zero target handling in math_score

### DIFF
--- a/internvl_chat/tools/reasoning_data_pipeline/utils/accuracy_reward.py
+++ b/internvl_chat/tools/reasoning_data_pipeline/utils/accuracy_reward.py
@@ -288,12 +288,14 @@ def math_score(prediction: str, target: str, max_relative_change: float = 1e-3) 
 
     prediction_float = _to_float(prediction)
     target_float = _to_float(target)
-    if prediction_float is not None and target_float:
-        relative_change = abs(prediction_float -
-                              target_float) / abs(target_float)
+    if prediction_float is not None and target_float is not None:
+        if target_float == 0:
+            return abs(prediction_float) <= max_relative_change
+
+        relative_change = abs(prediction_float - target_float) / abs(target_float)
         return relative_change <= max_relative_change
-    else:
-        return prediction.lower() == target.lower()
+
+    return prediction.lower() == target.lower()
 
 
 # https://github.com/google-research/pix2struct/blob/main/pix2struct/metrics.py#L81

--- a/tests/test_accuracy_reward.py
+++ b/tests/test_accuracy_reward.py
@@ -1,0 +1,20 @@
+import unittest
+
+from internvl_chat.tools.reasoning_data_pipeline.utils.accuracy_reward import (
+    math_score,
+)
+
+
+class MathScoreTest(unittest.TestCase):
+    def test_equivalent_zero_values_are_equal(self):
+        self.assertTrue(math_score("0.0", "0"))
+
+    def test_different_value_is_not_equal_to_zero(self):
+        self.assertFalse(math_score("1", "0"))
+
+    def test_equivalent_non_zero_values_are_still_equal(self):
+        self.assertTrue(math_score("1.0", "1"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Handle numeric zero targets in `math_score`
- Avoid division by zero when computing relative change
- Add regression tests for zero, different, and non-zero equivalent values

Previously, the condition used the truthiness of `target_float`. As a result,
a numeric target of `0.0` fell back to string comparison, causing equivalent
values such as `"0.0"` and `"0"` to be considered different.

## Testing

```text
python -m unittest discover -s tests -v