### PR TITLE
docs: fix InternVL requirements link

### DIFF
--- a/internvl_chat/README.md
+++ b/internvl_chat/README.md
@@ -6,7 +6,7 @@ This folder contains the implementation of the InternVL-Chat.
 
 ### 🌟 **Get Started**
 
-- **Installation**: 🌱 [Installation Guide](https://internvl.readthedocs.io/en/latest/get_started/installation.html) | 📄 [requirements.txt](./requirements.txt)
+- **Installation**: 🌱 [Installation Guide](https://internvl.readthedocs.io/en/latest/get_started/installation.html) | 📄 [internvl_chat.txt](./internvl_chat.txt)
 - **Chat Data Format**: 📝 [Meta File](https://internvl.readthedocs.io/en/latest/get_started/chat_data_format.html#meta-file) | ✏️ [Text](https://internvl.readthedocs.io/en/latest/get_started/chat_data_format.html#pure-text-data) | 🖼️ [Single-Image](https://internvl.readthedocs.io/en/latest/get_started/chat_data_format.html#single-image-data) | 🖼️🖼️ [Multi-Image](https://internvl.readthedocs.io/en/latest/get_started/chat_data_format.html#multi-image-data) | 🎥 [Video](https://internvl.readthedocs.io/en/latest/get_started/chat_data_format.html#video-data)
 - **Local Chat Demo**: 🤖 [Streamlit Demo](https://internvl.readthedocs.io/en/latest/get_started/local_chat_demo.html#streamlit-demo)
 - **InternVL-Chat API**: 🌐 [InternVL2-Pro](https://internvl.readthedocs.io/en/latest/get_started/internvl_chat_api.html#official-api-of-internvl2-pro)


### PR DESCRIPTION
## Summary
- Point the InternVL-Chat README to the existing internvl_chat.txt file.
- Prevent users from following a broken local dependency link.

## Testing
- git diff --check
- Verified there are no missing relative Markdown links.